### PR TITLE
allow component to inherit font family choices

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1,7 +1,7 @@
 <style>
   .v-select {
     position: relative;
-    font-family: sans-serif;
+    font-family: inherit;
   }
 
   .v-select,


### PR DESCRIPTION
I ran into this issue where the component was using the browser's default san-serif font, which of course we don't use. This will allow it to just take the font from the application its used in and continue on without much friction.